### PR TITLE
fix(build): Define `mypy` strict mode globally

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,3 +113,6 @@ tools = ["py.typed"]
 
 [tool.coverage.run]
 omit = ["across/tools/_version.py"]
+
+[tool.mypy]
+strict = true


### PR DESCRIPTION
## Title

fix(build): Define `mypy` strict mode globally

### Description

Defines `mypy` strict mode in `pyproject.toml` so that this is defined globally, rather than just in `.pre-commit.yaml`. This way `mypy` errors flagged up by `pre-commit` are also flagged up inline in VSCode and when running `mypy` on the command line.

### Related Issue(s)

Resolves #17 

### Reviewers

@swyatt7 

### Acceptance Criteria

Accept that we want to go all-in on strict mode.

### Testing

Tested my running `mypy` on the command line, and seeing errors flagged up by `mypy` as part of running `pre-commit run`.