### PR TITLE
fix(python): Update code for minimum Python version of 3.10

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4

--- a/across/tools/core/config.py
+++ b/across/tools/core/config.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -22,8 +20,8 @@ class Config(BaseConfig):
         Space-Track.org password
     """
 
-    SPACETRACK_USER: Optional[str] = None
-    SPACETRACK_PWD: Optional[str] = None
+    SPACETRACK_USER: str | None = None
+    SPACETRACK_PWD: str | None = None
 
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 

--- a/across/tools/core/schemas/bandpass.py
+++ b/across/tools/core/schemas/bandpass.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal, Optional, Union
+from typing import Any, Literal
 
 from astropy import units as u  # type: ignore[import-untyped]
 
@@ -17,9 +17,9 @@ class BaseBandpass(BaseSchema):
         max (float | None): The maximum value of the bandpass range.
     """
 
-    filter_name: Optional[str] = None
-    min: Optional[float] = None
-    max: Optional[float] = None
+    filter_name: str | None = None
+    min: float | None = None
+    max: float | None = None
 
 
 class WavelengthBandpass(BaseBandpass):
@@ -41,9 +41,9 @@ class WavelengthBandpass(BaseBandpass):
     """
 
     type: Literal["WAVELENGTH"] = "WAVELENGTH"
-    central_wavelength: Optional[float] = None
-    peak_wavelength: Optional[float] = None
-    bandwidth: Optional[float] = None
+    central_wavelength: float | None = None
+    peak_wavelength: float | None = None
+    bandwidth: float | None = None
     unit: WavelengthUnit
 
     def model_post_init(self, __context: Any) -> None:
@@ -156,7 +156,7 @@ class FrequencyBandpass(BaseBandpass):
             raise MinMaxValueError("Frequency values must be positive.")
 
 
-def convert_to_wave(bandpass: Union[EnergyBandpass, FrequencyBandpass]) -> WavelengthBandpass:
+def convert_to_wave(bandpass: EnergyBandpass | FrequencyBandpass) -> WavelengthBandpass:
     """
     Converts a given EnergyBandpass or FrequencyBandpass to a WavelengthBandPass.
 

--- a/across/tools/core/schemas/tle.py
+++ b/across/tools/core/schemas/tle.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import Any, Optional
+from typing import Any
 
 from pydantic import Field, model_validator
 
@@ -27,8 +27,8 @@ class TLEBase(BaseSchema):
     Each TLE line must be exactly 69 characters long per NORAD specification.
     """
 
-    norad_id: Optional[int] = None
-    satellite_name: Optional[str] = None
+    norad_id: int | None = None
+    satellite_name: str | None = None
     tle1: str = Field(min_length=69, max_length=69, pattern=r"1 .{67}")
     tle2: str = Field(min_length=69, max_length=69, pattern=r"2 .{67}")
 

--- a/across/tools/ephemeris/base.py
+++ b/across/tools/ephemeris/base.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
-from typing import Optional, Union
 
 import astropy.units as u  # type: ignore[import-untyped]
 import numpy as np
@@ -91,9 +90,9 @@ class Ephemeris(ABC):
     moon: SkyCoord
     sun: SkyCoord
     earth: SkyCoord
-    longitude: Optional[Longitude]
-    latitude: Optional[Latitude]
-    height: Optional[u.Quantity]
+    longitude: Longitude | None
+    latitude: Latitude | None
+    height: u.Quantity | None
     earth_radius_angle: Angle
     moon_radius_angle: Angle
     sun_radius_angle: Angle
@@ -101,9 +100,9 @@ class Ephemeris(ABC):
 
     def __init__(
         self,
-        begin: Union[datetime, Time],
-        end: Union[datetime, Time],
-        step_size: Union[int, TimeDelta, timedelta] = 60,
+        begin: datetime | Time,
+        end: datetime | Time,
+        step_size: int | TimeDelta | timedelta = 60,
     ) -> None:
         # Convert begin and end to astropy Time
         self.begin = begin if isinstance(begin, Time) else Time(begin)

--- a/across/tools/ephemeris/ground_ephem.py
+++ b/across/tools/ephemeris/ground_ephem.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-from typing import Optional, Union
 
 import astropy.units as u  # type: ignore[import-untyped]
 from astropy.coordinates import (  # type: ignore[import-untyped]
@@ -61,20 +60,20 @@ class GroundEphemeris(Ephemeris):
     """
 
     # Longitude of Observatory on Earth
-    longitude: Optional[Longitude]
+    longitude: Longitude | None
     # Latitude of Observatory on Earth
-    latitude: Optional[Latitude]
+    latitude: Latitude | None
     # Height of the Observatory on Earth
-    height: Optional[u.Quantity]
+    height: u.Quantity | None
 
     def __init__(
         self,
-        begin: Union[datetime, Time],
-        end: Union[datetime, Time],
-        step_size: Union[int, TimeDelta, timedelta] = 60,
-        latitude: Optional[Latitude] = None,
-        longitude: Optional[Longitude] = None,
-        height: Optional[u.Quantity] = None,
+        begin: datetime | Time,
+        end: datetime | Time,
+        step_size: int | TimeDelta | timedelta = 60,
+        latitude: Latitude | None = None,
+        longitude: Longitude | None = None,
+        height: u.Quantity | None = None,
     ) -> None:
         super().__init__(begin, end, step_size)
         self.latitude = latitude
@@ -97,9 +96,9 @@ class GroundEphemeris(Ephemeris):
 
 
 def compute_ground_ephemeris(
-    begin: Union[datetime, Time],
-    end: Union[datetime, Time],
-    step_size: Union[int, timedelta, TimeDelta],
+    begin: datetime | Time,
+    end: datetime | Time,
+    step_size: int | timedelta | TimeDelta,
     latitude: Latitude,
     longitude: Longitude,
     height: u.Quantity,

--- a/across/tools/ephemeris/jpl_ephem.py
+++ b/across/tools/ephemeris/jpl_ephem.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-from typing import Optional, Union
 
 import astropy.units as u  # type: ignore[import-untyped]
 import astroquery.jplhorizons as jpl  # type: ignore[import-untyped]
@@ -60,14 +59,14 @@ class JPLEphemeris(Ephemeris):
     """
 
     # NAIF ID of object for JPL Horizons or Spice Kernel
-    naif_id: Optional[int] = None
+    naif_id: int | None = None
 
     def __init__(
         self,
-        begin: Union[datetime, Time],
-        end: Union[datetime, Time],
-        step_size: Union[int, TimeDelta, timedelta] = 60,
-        naif_id: Optional[int] = None,
+        begin: datetime | Time,
+        end: datetime | Time,
+        step_size: int | TimeDelta | timedelta = 60,
+        naif_id: int | None = None,
     ) -> None:
         super().__init__(begin, end, step_size)
         self.naif_id = naif_id
@@ -119,9 +118,9 @@ class JPLEphemeris(Ephemeris):
 
 
 def compute_jpl_ephemeris(
-    begin: Union[datetime, Time],
-    end: Union[datetime, Time],
-    step_size: Union[int, timedelta, TimeDelta],
+    begin: datetime | Time,
+    end: datetime | Time,
+    step_size: int | timedelta | TimeDelta,
     naif_id: int,
 ) -> Ephemeris:
     """

--- a/across/tools/ephemeris/spice_ephem.py
+++ b/across/tools/ephemeris/spice_ephem.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-from typing import Optional, Union
 
 import astropy.units as u  # type: ignore[import-untyped]
 import numpy as np
@@ -72,18 +71,18 @@ class SPICEEphemeris(Ephemeris):
     """
 
     # NAIF ID of object for JPL Horizons or Spice Kernel
-    naif_id: Optional[int] = None
+    naif_id: int | None = None
 
     # URL of spacecraft SPICE Kernel
-    spice_kernel_url: Optional[str] = None
+    spice_kernel_url: str | None = None
 
     def __init__(
         self,
-        begin: Union[datetime, Time],
-        end: Union[datetime, Time],
-        step_size: Union[int, TimeDelta, timedelta] = 60,
-        spice_kernel_url: Optional[str] = None,
-        naif_id: Optional[int] = None,
+        begin: datetime | Time,
+        end: datetime | Time,
+        step_size: int | TimeDelta | timedelta = 60,
+        spice_kernel_url: str | None = None,
+        naif_id: int | None = None,
     ) -> None:
         super().__init__(begin, end, step_size)
         self.spice_kernel_url = spice_kernel_url
@@ -134,9 +133,9 @@ class SPICEEphemeris(Ephemeris):
 
 
 def compute_spice_ephemeris(
-    begin: Union[datetime, Time],
-    end: Union[datetime, Time],
-    step_size: Union[int, timedelta, TimeDelta],
+    begin: datetime | Time,
+    end: datetime | Time,
+    step_size: int | timedelta | TimeDelta,
     spice_kernel_url: str,
     naif_id: int,
 ) -> Ephemeris:

--- a/across/tools/ephemeris/tle_ephem.py
+++ b/across/tools/ephemeris/tle_ephem.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-from typing import Optional, Union
 
 import astropy.units as u  # type: ignore[import-untyped]
 from astropy.coordinates import (  # type: ignore[import-untyped]
@@ -67,14 +66,14 @@ class TLEEphemeris(Ephemeris):
     """
 
     # TLE for calculating LEO satellites
-    tle: Optional[TLE] = None
+    tle: TLE | None = None
 
     def __init__(
         self,
-        begin: Union[datetime, Time],
-        end: Union[datetime, Time],
-        step_size: Union[int, TimeDelta, timedelta] = 60,
-        tle: Optional[TLE] = None,
+        begin: datetime | Time,
+        end: datetime | Time,
+        step_size: int | TimeDelta | timedelta = 60,
+        tle: TLE | None = None,
     ) -> None:
         super().__init__(begin, end, step_size)
         self.tle = tle
@@ -106,9 +105,9 @@ class TLEEphemeris(Ephemeris):
 
 
 def compute_tle_ephemeris(
-    begin: Union[datetime, Time],
-    end: Union[datetime, Time],
-    step_size: Union[int, timedelta, TimeDelta],
+    begin: datetime | Time,
+    end: datetime | Time,
+    step_size: int | timedelta | TimeDelta,
     tle: TLE,
 ) -> Ephemeris:
     """

--- a/across/tools/footprint/healpix_joins.py
+++ b/across/tools/footprint/healpix_joins.py
@@ -26,7 +26,7 @@ def outer(footprints: list[Footprint], order: int = 10) -> list[int]:
         total_pixels.extend(footprint.query_pixels(order=order))
 
     duplicates = find_duplicates(total_pixels)
-    outer_pixels = list(set([x for x in total_pixels if x not in duplicates]))
+    outer_pixels = list({x for x in total_pixels if x not in duplicates})
 
     return outer_pixels
 

--- a/across/tools/tle/tle.py
+++ b/across/tools/tle/tle.py
@@ -4,7 +4,6 @@
 
 
 from datetime import datetime, timedelta
-from typing import Optional
 
 from httpx import HTTPStatusError
 from spacetrack import AuthenticationError, SpaceTrackClient  # type: ignore[import-untyped]
@@ -46,19 +45,19 @@ class TLEFetch:
     """
 
     # Configuration parameters
-    satellite_name: Optional[str]
+    satellite_name: str | None
     norad_id: int
     epoch: datetime
-    spacetrack_user: Optional[str]
-    spacetrack_pwd: Optional[str]
+    spacetrack_user: str | None
+    spacetrack_pwd: str | None
 
     def __init__(
         self,
         norad_id: int,
         epoch: datetime,
-        satellite_name: Optional[str] = None,
-        spacetrack_user: Optional[str] = None,
-        spacetrack_pwd: Optional[str] = None,
+        satellite_name: str | None = None,
+        spacetrack_user: str | None = None,
+        spacetrack_pwd: str | None = None,
     ):
         self.norad_id = norad_id
         self.epoch = epoch
@@ -66,7 +65,7 @@ class TLEFetch:
         self.spacetrack_user = spacetrack_user or config.SPACETRACK_USER
         self.spacetrack_pwd = spacetrack_pwd or config.SPACETRACK_PWD
 
-    def get(self) -> Optional[TLE]:
+    def get(self) -> TLE | None:
         """
         Return TLE epoch closest to the requested epoch, within +/- 7 days. If
         no TLE data is found, return None.
@@ -130,9 +129,9 @@ class TLEFetch:
 def get_tle(
     norad_id: int,
     epoch: datetime,
-    spacetrack_user: Optional[str] = None,
-    spacetrack_pwd: Optional[str] = None,
-) -> Optional[TLE]:
+    spacetrack_user: str | None = None,
+    spacetrack_pwd: str | None = None,
+) -> TLE | None:
     """
     Gets the Two-Line Element (TLE) data for a satellite at a specific epoch.
     Credentials for space-track.org can be provided as arguments, or they can

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "Programming Language :: Python",
 ]
 dynamic = ["version"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "astropy",
     "numpy",

--- a/tests/tools/core/test_bandpass.py
+++ b/tests/tools/core/test_bandpass.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import numpy as np
 import pytest
 
@@ -27,7 +25,7 @@ class TestBandpassSchema:
                 (2, 1),
             ],
         )
-        def test_should_throw_value_error_min_max(self, min: Optional[float], max: Optional[float]) -> None:
+        def test_should_throw_value_error_min_max(self, min: float | None, max: float | None) -> None:
             """
             Parameterized tests that validate bad instantiations for WavelengthBandpass.
                 Should raise ValueError when min=None, max=None
@@ -43,7 +41,7 @@ class TestBandpassSchema:
             [(None, None), (None, 1), (1, None), (-1, 1), (1, -1)],
         )
         def test_should_throw_value_error_central_wavelength_bandwidth(
-            self, central_wavelength: Optional[float], bandwidth: Optional[float]
+            self, central_wavelength: float | None, bandwidth: float | None
         ) -> None:
             """
             Parameterized tests that validate bad instantiations for WavelengthBandpass.
@@ -102,7 +100,7 @@ class TestBandpassSchema:
                 (1, -1),
             ],
         )
-        def test_should_throw_value_error_min_max(self, min: Optional[float], max: Optional[float]) -> None:
+        def test_should_throw_value_error_min_max(self, min: float | None, max: float | None) -> None:
             """
             Parameterized tests that validate bad instantiations for EnergyBandpass.
                 Should raise ValueError when min=None, max=None
@@ -127,7 +125,7 @@ class TestBandpassSchema:
                 (1, -1),
             ],
         )
-        def test_should_throw_value_error_min_max(self, min: Optional[float], max: Optional[float]) -> None:
+        def test_should_throw_value_error_min_max(self, min: float | None, max: float | None) -> None:
             """
             Parameterized tests that validate bad instantiations for FrequencyBandpass.
                 Should raise ValueError when min=None, max=None


### PR DESCRIPTION
## Title

fix(python): Update code for minimum Python version of 3.10

### Description

Bump minimum version of Python from 3.9 to 3.10. This allows us to use the Union operator `|` to define types. This means that typing like `Optional[str]` becomes `str | None` and `Union[int, float]` becomes `int | float`. This code is easier to read and more consistent with the typing used in `across-server`.

Removes Python 3.9 checks in Github Actions.

### Related Issue(s)

Resolves #27 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

Operations of code should be identical to before, only with updating typing to the Python >=3.10 standards.

### Testing

Perform pytests and run mypy to check that all types pass. No actual code changes, only type hinting, so operation of code should be unmodified.