### PR TITLE
fix(typing): Removed type:ignore that was causing mypy to thrown error in CI

### DIFF
--- a/across/tools/core/schemas/bandpass.py
+++ b/across/tools/core/schemas/bandpass.py
@@ -75,19 +75,19 @@ class WavelengthBandpass(BaseBandpass):
         if not all([self.central_wavelength > 0, self.bandwidth > 0]):
             raise BandwidthValueError("Central wavelength and bandwidth must be positive.")
 
-        self.bandwidth = (
+        self.bandwidth = float(
             (self.bandwidth * u.Unit(self.unit.value)).to(u.Unit(WavelengthUnit.ANGSTROM.value)).value
         )
 
-        self.central_wavelength = (
+        self.central_wavelength = float(
             (self.central_wavelength * u.Unit(self.unit.value))
             .to(u.Unit(WavelengthUnit.ANGSTROM.value))
             .value
         )
 
-        self.min = self.central_wavelength - (self.bandwidth)  # type: ignore
+        self.min = self.central_wavelength - self.bandwidth
 
-        self.max = self.central_wavelength + (self.bandwidth)  # type: ignore
+        self.max = self.central_wavelength + self.bandwidth
 
         self.unit = WavelengthUnit.ANGSTROM
 


### PR DESCRIPTION

## Title

fix(typing): Removed type:ignore that was causing mypy to thrown error in CI

### Description

Removes need for `# type: ignore` by explicitly typing two values that always will be floats, but lose their `float` typing due to `astropy` lacking typing support.

### Related Issue(s)

Resolves #34 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

Code should pass mypy tests without the `#type: ignore`.

### Testing

Run mypy and pytest. Check out if this PR passes CI checks.
