### PR TITLE
fix(ephemeris): Add missing `latitude`/`longitude`/`height` attributes to `TLEEphemeris`

### DIFF
--- a/across/tools/ephemeris/base.py
+++ b/across/tools/ephemeris/base.py
@@ -90,9 +90,9 @@ class Ephemeris(ABC):
     moon: SkyCoord
     sun: SkyCoord
     earth: SkyCoord
-    longitude: Longitude | None
-    latitude: Latitude | None
-    height: u.Quantity | None
+    longitude: Longitude | None = None
+    latitude: Latitude | None = None
+    height: u.Quantity | None = None
     earth_radius_angle: Angle
     moon_radius_angle: Angle
     sun_radius_angle: Angle

--- a/across/tools/ephemeris/tle_ephem.py
+++ b/across/tools/ephemeris/tle_ephem.py
@@ -97,6 +97,9 @@ class TLEEphemeris(Ephemeris):
         )
         itrs = teme.transform_to("itrs")
         self.earth_location = itrs.earth_location
+        self.latitude = itrs.earth_location.lat
+        self.longitude = itrs.earth_location.lon
+        self.height = itrs.earth_location.height
 
         # Calculate satellite position in GCRS coordinate system vector as
         # array of x,y,z vectors in units of km, and velocity vector as array


### PR DESCRIPTION
## Title

fix(ephemeris): Add missing `latitude`/`longitude`/`height` attributes to `TLEEphemeris`

### Description

This PR ensures that the values of `longitude`, `latitude` and `height` are set to the default value of `None` for any instantiated `Ephemeris` class. In addition for the `TLEEphemeris` class, it ensures that these values, which care calculated in `earth_location` are assigned.

#### Updates to geographic coordinate handling:

* [`across/tools/ephemeris/base.py`](diffhunk://#diff-157caf896035b0641be3ba2cce4de849792f5f402c299630e735cfe354ab018eL93-R95): Updated the `Ephemeris` class to set default values (`None`) for `longitude`, `latitude`, and `height` attributes, ensuring these attributes are always initialized even if no values are provided.
* [`across/tools/ephemeris/tle_ephem.py`](diffhunk://#diff-2c0cd0b3aaf5705fe734766cacd478e3e10349e8ed9631e93d6e233def7f7252R100-R102): Fixed `prepare_data` method to populate `latitude`, `longitude`, and `height` attributes using the `earth_location` property derived from the ITRS coordinate system.

### Related Issue(s)

Resolves #36 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

* `TLEEphemeris` class should populate `latitude`, `longitude` and `height` parameters when `compute()` is run. 
* The default values of these parameters in any instantiated `Ephemeris` class should be `None`.

### Testing

Run the following code to confirm that these parameters are being calculated:
```python
from datetime import datetime

from across.tools.ephemeris import compute_tle_ephemeris
from across.tools.tle import get_tle

begin = datetime(2025, 6, 10, 0, 0, 0)
end = datetime(2025, 6, 11, 0, 0, 0)

swift_tle = get_tle(norad_id=28485, epoch=begin)
ephemeris = compute_tle_ephemeris(begin=begin, end=end, tle=swift_tle, step_size=60)

print(ephemeris.latitude)
print(ephemeris.longitude)
print(ephemeris.height)
```



