### PR TITLE
fix(visibility): add `min_vis` argument to `compute_ephemeris_visibility`

### DIFF
--- a/across/tools/visibility/ephemeris_visibility.py
+++ b/across/tools/visibility/ephemeris_visibility.py
@@ -126,6 +126,7 @@ def compute_ephemeris_visibility(
     step_size: u.Quantity = 60 * u.s,
     observatory_name: str = "Observatory",
     observatory_id: UUID | None = None,
+    min_vis: int = 0,
 ) -> EphemerisVisibility:
     """
     Compute visibility windows based on ephemeris data and constraints.
@@ -152,6 +153,8 @@ def compute_ephemeris_visibility(
         Name of the observatory for which visibility is calculated, default is "Observatory".
     observatory_id : UUID, optional
         Unique identifier for the observatory, if available.
+    min_vis : int, optional
+        Minimum visibility time for a window to be considered valid, default is 0 seconds.
 
     Returns
     -------
@@ -168,6 +171,7 @@ def compute_ephemeris_visibility(
         end=end,
         step_size=step_size,
         observatory_name=observatory_name,
+        min_vis=min_vis,
     )
     if observatory_id is not None:
         vis.observatory_id = observatory_id


### PR DESCRIPTION
## Title

fix(visibility): add `min_vis` argument to `compute_ephemeris_visibility`

### Description

Adds `min_vis` argument to `compute_ephemeris_visibility` to allow minimum visibility seconds to be set.

### Related Issue(s)

Resolves #41 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

Should allow minimum visibility to be set using the helper function.

### Testing

Run the visibility test e.g. shown in PR #40, and set `min_vis = 1000`, to see that windows with exposure time less than 1000s are filtered out.
