### PR TITLE
fix(visibility): Fix enum representations appearing in `constraint_reason`

### DIFF
--- a/across/tools/visibility/base.py
+++ b/across/tools/visibility/base.py
@@ -237,8 +237,8 @@ class Visibility(ABC, BaseSchema):
             window = Window(begin=constrained_date_begin, end=constrained_date_end)
             visibility = int((self.timestamp[i[1]] - self.timestamp[i[0]]).to_value(u.s))
             constraint_reason = ConstraintReason(
-                start_reason=f"{self.observatory_name} {self._constraint(i[0] - 1)}",
-                end_reason=f"{self.observatory_name} {self._constraint(i[1] + 1)}",
+                start_reason=f"{self.observatory_name} {self._constraint(i[0] - 1).value}",
+                end_reason=f"{self.observatory_name} {self._constraint(i[1] + 1).value}",
             )
 
             visibility_window = VisibilityWindow(


### PR DESCRIPTION
## Title

fix(visibility): Fix enum representations appearing in `constraint_reason`

### Description

Fixes the issue where sometimes a representation of the Enum, instead of the value, could appear in the `start_reason` and `end_reason` values of `constraint_reason` in `visibility_windows`, like this:

```json
"constraint_reason": {
        "start_reason": "Observatory ConstraintType.WINDOW",
        "end_reason": "Observatory ConstraintType.EARTH"
      }
```

### Related Issue(s)

Resolves #43 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

`start_reason` and `end_reason` should be pure strings.

### Testing

As this only seems to show up when running this code in the API endpoint, and not in Jupyter, the only way to test this is to run a visibility calculation (e.g. like in PR #40) and verify that it doesn't break things, or to run the visibility calculator in `across-server` and verify that the bad behavior has gone away.
