### PR TITLE
fix(visibility): fix issue instantiating `SAAPolygonConstraint` from JSON

### DIFF
--- a/across/tools/visibility/constraints/polygon.py
+++ b/across/tools/visibility/constraints/polygon.py
@@ -1,4 +1,4 @@
-from pydantic import field_serializer
+from pydantic import field_serializer, field_validator
 from shapely import Polygon
 
 from .base import ConstraintABC
@@ -16,3 +16,17 @@ class PolygonConstraint(ConstraintABC):
     def serialize_polygon(self, polygon: Polygon) -> list[tuple[float, ...]]:
         """Serialize the polygon to a list of tuples"""
         return [co for co in polygon.exterior.coords]
+
+    @field_validator("polygon", mode="before")
+    @classmethod
+    def validate_polygon(
+        cls, v: Polygon | list[tuple[float, ...]] | tuple[tuple[float, ...], ...] | None
+    ) -> Polygon | None:
+        """Validate and convert polygon input"""
+        if v is None:
+            return v
+        if isinstance(v, Polygon):
+            return v
+        if isinstance(v, (list, tuple)):
+            return Polygon(v)
+        raise ValueError(f"Cannot convert {type(v)} to Polygon")

--- a/tests/tools/visibility/constraints/saa_test.py
+++ b/tests/tools/visibility/constraints/saa_test.py
@@ -33,6 +33,25 @@ class TestSAAPolygonConstraintInstantiation:
         assert isinstance(saa_polygon_constraint.polygon, Polygon)
         assert saa_polygon_constraint.polygon.exterior.coords[0] == (39.0, -30.0)
 
+    def test_saa_polygon_constraint_instantiation_from_json(
+        self, saa_polygon_constraint: SAAPolygonConstraint
+    ) -> None:
+        """Test that SAAPolygonConstraint can be instantiated from JSON."""
+        json_data = saa_polygon_constraint.model_dump_json()
+        saa_constraint = SAAPolygonConstraint.model_validate_json(json_data)
+        assert saa_constraint is not None
+        assert isinstance(saa_constraint, SAAPolygonConstraint)
+
+    def test_saa_polygon_constraint_instantiation_from_dict_bad_polygon_type(
+        self, saa_polygon_constraint: SAAPolygonConstraint
+    ) -> None:
+        """Test that SAAPolygonConstraint raises ValidationError with invalid polygon data."""
+        model_dict = saa_polygon_constraint.model_dump()
+        model_dict["polygon"] = 1
+
+        with pytest.raises(ValueError):
+            SAAPolygonConstraint.model_validate(model_dict)
+
 
 class TestSAAPolygonConstraintCompute:
     """Test suite for the computing constraints with the SAAPolygonConstraint class."""


### PR DESCRIPTION
## Title

fix(visibility): fix issue instantiating `SAAPolygonConstraint` from JSON

### Description

This PR fixes an issue where `PolygonConstraint` based classes were not able to be instantiated from JSON. This adds a `field_validator` to the `PolygonConstraint` Pydantic model that ensures that the `polygon` argument is correctly converted into a Shapely `Polygon` object from either a `list`, `tuple` or an existing `Polygon` and returns `None` if `None`. If the value of `polygon` is the wrong type, this raises a `ValueError`. 

Unit tests for this additional code are also added.

### Related Issue(s)

Resolves #45 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

`SAAPolygonConstraint` and other `PolygonConstraint` based classes should be able to be constructed from JSON. 

### Testing

Verify that the code below correctly runs:

```python
from shapely import Polygon

from across.tools.visibility.constraints.saa import SAAPolygonConstraint

saa_constraint = SAAPolygonConstraint(
    polygon=Polygon(
        [
            (39.0, -30.0),
            (36.0, -26.0),
            (28.0, -21.0),
            (6.0, -12.0),
            (-5.0, -6.0),
            (-21.0, 2.0),
            (-30.0, 3.0),
            (-45.0, 2.0),
            (-60.0, -2.0),
            (-75.0, -7.0),
            (-83.0, -10.0),
            (-87.0, -16.0),
            (-86.0, -23.0),
            (-83.0, -30.0),
        ]
    )
)

SAAPolygonConstraint.model_validate_json(saa_constraint.model_dump_json())
```
