### PR TITLE
fix(ephemeris): Round begin/end to step_size for consistency

### DIFF
--- a/across/tools/ephemeris/base.py
+++ b/across/tools/ephemeris/base.py
@@ -116,9 +116,10 @@ class Ephemeris(ABC):
         elif isinstance(step_size, (int, float)):
             self.step_size = TimeDelta(step_size * u.s)
 
-        # Round the end time to the nearest step size
-        steps = np.ceil(self.end.unix / self.step_size.to_value(u.s))
-        self.end = Time(steps * self.step_size.to_value(u.s), format="unix")
+        # Align begin/end to step grid (floor)
+        s = self.step_size.to_value(u.s)
+        self.begin = Time((self.begin.unix // s) * s, format="unix")
+        self.end = Time((self.end.unix // s) * s, format="unix")
 
         # Compute range of timestamps
         self.timestamp = self._compute_timestamp()


### PR DESCRIPTION
## Title

fix(ephemeris): Round begin/end to step_size for consistency

### Description

This pull request updates the initialization logic in `across/tools/ephemeris/base.py` to improve how time ranges are aligned with the step grid. The main change ensures both the `begin` and `end` times are consistently aligned to the step grid using floor division, which can help avoid off-by-one errors and ensure predictable time intervals.

Time alignment improvements:

* Changed the logic to align both `begin` and `end` times to the nearest lower step boundary using floor division, instead of only rounding the `end` time up to the nearest step. (`across/tools/ephemeris/base.py`)

### Related Issue(s)

Resolves #47 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

Visibility Calculator needs to work with `begin` and `end` values that can have seconds and fractional seconds.

### Testing

Tested in SwaggerUI as described in Issue #47 
