### PR TITLE
fix(constraints): making constraint polygon nullable

### DIFF
--- a/across/tools/visibility/constraints/alt_az.py
+++ b/across/tools/visibility/constraints/alt_az.py
@@ -33,7 +33,7 @@ class AltAzConstraint(PolygonConstraint):
 
     short_name: str = "AltAz"
     name: Literal[ConstraintType.ALT_AZ] = ConstraintType.ALT_AZ
-    polygon: Polygon | None
+    polygon: Polygon | None = None
     altitude_min: float | None = Field(default=None, ge=0, le=90)
     altitude_max: float | None = Field(default=None, ge=0, le=90)
     azimuth_min: float | None = Field(default=None, ge=0, lt=360)

--- a/across/tools/visibility/constraints/polygon.py
+++ b/across/tools/visibility/constraints/polygon.py
@@ -13,9 +13,11 @@ class PolygonConstraint(ConstraintABC):
     polygon: Polygon | None = None
 
     @field_serializer("polygon")
-    def serialize_polygon(self, polygon: Polygon) -> list[tuple[float, ...]]:
+    def serialize_polygon(self, polygon: Polygon | None) -> list[tuple[float, ...]] | None:
         """Serialize the polygon to a list of tuples"""
-        return [co for co in polygon.exterior.coords]
+        if polygon:
+            return [co for co in polygon.exterior.coords]
+        return None
 
     @field_validator("polygon", mode="before")
     @classmethod


### PR DESCRIPTION
### Description

This PR accounts for nullable polygons in PolygonConstraint initialization. Bug found in creating an AltAzConstraint without a polygon.

### Related Issue(s)

https://github.com/ACROSS-Team/across-tools/issues/56

### Reviewers

@jak574 @ACROSS-Team/developers 

### Acceptance Criteria

You can create an AltAzConstraint without a polygon.
Migrations still run on server (they do)

### Testing

This raises no issues
```
from across.tools.visibility.constraints import AltAzConstraint

constraint = AltAzConstraint()
```
