### PR TITLE
feat(visibility): allow visibility constraints to record calculated values in output

### DIFF
--- a/across/tools/core/schemas/visibility.py
+++ b/across/tools/core/schemas/visibility.py
@@ -1,5 +1,9 @@
 from uuid import UUID
 
+import astropy.units as u  # type: ignore[import-untyped]
+from astropy.coordinates import SkyCoord  # type: ignore[import-untyped]
+from pydantic import Field
+
 from ..enums.constraint_type import ConstraintType
 from .base import BaseSchema
 from .custom_types import AstropyDateTime
@@ -37,3 +41,29 @@ class VisibilityWindow(BaseSchema):
     window: Window
     max_visibility_duration: int
     constraint_reason: ConstraintReason
+
+
+class VisibilityComputedValues(BaseSchema):
+    """
+    A class to hold computed values for used by in constraint calculations.
+    """
+
+    sun_angle: u.Quantity | None = Field(
+        default=None, description="Angular distance between the Sun and the coordinate"
+    )
+    moon_angle: u.Quantity | None = Field(
+        default=None, description="Angular distance between the Moon and the coordinate"
+    )
+    earth_angle: u.Quantity | None = Field(
+        default=None, description="Angular distance between the Earth and the coordinate"
+    )
+    alt_az: SkyCoord | None = Field(default=None, description="AltAz coordinates of the coordinate")
+
+    def merge(self, other: "VisibilityComputedValues") -> None:
+        """
+        Merge another VisibilityComputedValues into this one. Always updates
+        values from the other object if they are not None.
+        """
+        for field_name, value in other.model_dump().items():
+            if value is not None:
+                setattr(self, field_name, value)

--- a/across/tools/visibility/base.py
+++ b/across/tools/visibility/base.py
@@ -10,6 +10,7 @@ from astropy.time import Time, TimeDelta  # type: ignore[import-untyped]
 from pydantic import Field, model_validator
 
 from across.tools.core.schemas import AstropyDateTime, AstropyTimeDelta
+from across.tools.core.schemas.visibility import VisibilityComputedValues
 
 from ..core.enums.constraint_type import ConstraintType
 from ..core.schemas import (
@@ -74,6 +75,7 @@ class Visibility(ABC, BaseSchema):
         default_factory=OrderedDict, exclude=True
     )
     visibility_windows: list[VisibilityWindow] = []
+    computed_values: VisibilityComputedValues = Field(default_factory=VisibilityComputedValues)
 
     @model_validator(mode="before")
     @classmethod
@@ -190,6 +192,13 @@ class Visibility(ABC, BaseSchema):
         raise NotImplementedError("Subclasses must implement this method.")  # pragma: no cover
 
     @abstractmethod
+    def _merge_computed_values(self) -> None:
+        """
+        Abstract method to merge computed values from constraints.
+        """
+        raise NotImplementedError("Subclasses must implement this method.")  # pragma: no cover
+
+    @abstractmethod
     def prepare_data(self) -> None:
         """
         Abstract method to perform visibility calculation.
@@ -273,3 +282,4 @@ class Visibility(ABC, BaseSchema):
         self._compute_timestamp()
         self.prepare_data()
         self.visibility_windows = self._make_windows()
+        self._merge_computed_values()

--- a/across/tools/visibility/constraints/alt_az.py
+++ b/across/tools/visibility/constraints/alt_az.py
@@ -62,7 +62,7 @@ class AltAzConstraint(PolygonConstraint):
 
         # Convert the sky coordinates to Alt/Az coordinates
         assert ephemeris.earth_location is not None
-        alt_az = coordinate.transform_to(
+        self.computed_values.alt_az = coordinate.transform_to(
             AltAz(
                 obstime=time[i],
                 location=ephemeris.earth_location
@@ -72,21 +72,23 @@ class AltAzConstraint(PolygonConstraint):
         )
 
         # Initialize the constraint array as all False
-        in_constraint = np.zeros(len(alt_az), dtype=bool)
+        in_constraint = np.zeros(len(self.computed_values.alt_az), dtype=bool)
 
         # Calculate the basic Alt/Az min/max constraints
         if self.altitude_min is not None:
-            in_constraint |= alt_az.alt < self.altitude_min * u.deg
+            in_constraint |= self.computed_values.alt_az.alt < self.altitude_min * u.deg
         if self.altitude_max is not None:
-            in_constraint |= alt_az.alt > self.altitude_max * u.deg
+            in_constraint |= self.computed_values.alt_az.alt > self.altitude_max * u.deg
         if self.azimuth_min is not None:
-            in_constraint |= alt_az.az < self.azimuth_min * u.deg
+            in_constraint |= self.computed_values.alt_az.az < self.azimuth_min * u.deg
         if self.azimuth_max is not None:
-            in_constraint |= alt_az.az > self.azimuth_max * u.deg
+            in_constraint |= self.computed_values.alt_az.az > self.azimuth_max * u.deg
 
         # If a polygon is defined, then check if the Alt/Az is inside the polygon
         if self.polygon is not None:
-            in_constraint |= self.polygon.contains(points(alt_az.alt, alt_az.az))
+            in_constraint |= self.polygon.contains(
+                points(self.computed_values.alt_az.alt, self.computed_values.alt_az.az)
+            )
 
         # Return the value as a scalar or array
         return in_constraint

--- a/across/tools/visibility/constraints/base.py
+++ b/across/tools/visibility/constraints/base.py
@@ -5,9 +5,11 @@ from abc import ABC, abstractmethod
 import numpy as np
 from astropy.coordinates import SkyCoord  # type: ignore[import-untyped]
 from astropy.time import Time  # type: ignore[import-untyped]
+from pydantic import Field
 
 from ...core.enums import ConstraintType
 from ...core.schemas.base import BaseSchema
+from ...core.schemas.visibility import VisibilityComputedValues
 from ...ephemeris import Ephemeris
 
 
@@ -80,6 +82,7 @@ class ConstraintABC(BaseSchema, ABC):
 
     short_name: str
     name: ConstraintType
+    computed_values: VisibilityComputedValues = Field(default_factory=VisibilityComputedValues, exclude=True)
 
     @abstractmethod
     def __call__(self, time: Time, ephemeris: Ephemeris, coordinate: SkyCoord) -> np.typing.NDArray[np.bool_]:

--- a/across/tools/visibility/constraints/earth_limb.py
+++ b/across/tools/visibility/constraints/earth_limb.py
@@ -76,15 +76,17 @@ class EarthLimbConstraint(ConstraintABC):
 
         in_constraint = np.zeros(len(ephemeris.earth[i]), dtype=bool)
 
+        self.computed_values.earth_angle = SkyCoord(ephemeris.earth[i].ra, ephemeris.earth[i].dec).separation(
+            coordinate
+        )
+
         if self.min_angle is not None:
             in_constraint |= (
-                SkyCoord(ephemeris.earth[i].ra, ephemeris.earth[i].dec).separation(coordinate)
-                < ephemeris.earth_radius_angle[i] + self.min_angle * u.deg
+                self.computed_values.earth_angle < ephemeris.earth_radius_angle[i] + self.min_angle * u.deg
             )
         if self.max_angle is not None:
             in_constraint |= (
-                SkyCoord(ephemeris.earth[i].ra, ephemeris.earth[i].dec).separation(coordinate)
-                > ephemeris.earth_radius_angle[i] + self.max_angle * u.deg
+                self.computed_values.earth_angle > ephemeris.earth_radius_angle[i] + self.max_angle * u.deg
             )
 
         # Return the result as True or False, or an array of True/False

--- a/across/tools/visibility/constraints/logical.py
+++ b/across/tools/visibility/constraints/logical.py
@@ -155,6 +155,7 @@ class AndConstraint(ConstraintCoercionMixin, ConstraintABC):
         # AND all constraints together
         for constraint in self.constraints:
             result &= constraint(time=time, ephemeris=ephemeris, coordinate=coordinate)
+            self.computed_values.merge(constraint.computed_values)
 
         return result
 
@@ -233,6 +234,7 @@ class OrConstraint(ConstraintCoercionMixin, ConstraintABC):
         # OR all constraints together
         for constraint in self.constraints:
             result |= constraint(time=time, ephemeris=ephemeris, coordinate=coordinate)
+            self.computed_values.merge(constraint.computed_values)
 
         return result
 
@@ -299,7 +301,9 @@ class NotConstraint(ConstraintCoercionMixin, ConstraintABC):
         np.typing.NDArray[np.bool_]
             Boolean array where True indicates constraint is violated.
         """
-        return ~self.constraint(time=time, ephemeris=ephemeris, coordinate=coordinate)
+        constraint = ~self.constraint(time=time, ephemeris=ephemeris, coordinate=coordinate)
+        self.computed_values.merge(self.constraint.computed_values)
+        return constraint
 
 
 class XorConstraint(ConstraintCoercionMixin, ConstraintABC):
@@ -377,5 +381,6 @@ class XorConstraint(ConstraintCoercionMixin, ConstraintABC):
         # XOR all constraints together
         for constraint in self.constraints:
             result ^= constraint(time=time, ephemeris=ephemeris, coordinate=coordinate)
+            self.computed_values.merge(constraint.computed_values)
 
         return result

--- a/across/tools/visibility/constraints/moon_angle.py
+++ b/across/tools/visibility/constraints/moon_angle.py
@@ -66,16 +66,15 @@ class MoonAngleConstraint(ConstraintABC):
         assert ephemeris.moon is not None
 
         in_constraint = np.zeros(len(ephemeris.moon[i]), dtype=bool)
+
+        self.computed_values.moon_angle = SkyCoord(ephemeris.moon[i].ra, ephemeris.moon[i].dec).separation(
+            coordinate
+        )
+
         if self.min_angle is not None:
-            in_constraint |= (
-                SkyCoord(ephemeris.moon[i].ra, ephemeris.moon[i].dec).separation(coordinate)
-                < self.min_angle * u.deg
-            )
+            in_constraint |= self.computed_values.moon_angle < self.min_angle * u.deg
         if self.max_angle is not None:
-            in_constraint |= (
-                SkyCoord(ephemeris.moon[i].ra, ephemeris.moon[i].dec).separation(coordinate)
-                > self.max_angle * u.deg
-            )
+            in_constraint |= self.computed_values.moon_angle > self.max_angle * u.deg
 
         # Return the result as True or False, or an array of True/False
         return in_constraint

--- a/across/tools/visibility/constraints/sun_angle.py
+++ b/across/tools/visibility/constraints/sun_angle.py
@@ -72,16 +72,14 @@ class SunAngleConstraint(ConstraintABC):
         # Construct the constraint based on the minimum and maximum angles
         in_constraint = np.zeros(len(ephemeris.sun[i]), dtype=bool)
 
+        self.computed_values.sun_angle = SkyCoord(ephemeris.sun[i].ra, ephemeris.sun[i].dec).separation(
+            coordinate
+        )
+
         if self.min_angle is not None:
-            in_constraint |= (
-                SkyCoord(ephemeris.sun[i].ra, ephemeris.sun[i].dec).separation(coordinate)
-                < self.min_angle * u.deg
-            )
+            in_constraint |= self.computed_values.sun_angle < self.min_angle * u.deg
         if self.max_angle is not None:
-            in_constraint |= (
-                SkyCoord(ephemeris.sun[i].ra, ephemeris.sun[i].dec).separation(coordinate)
-                > self.max_angle * u.deg
-            )
+            in_constraint |= self.computed_values.sun_angle > self.max_angle * u.deg
 
         # Return the result as True or False, or an array of True/False
         return in_constraint

--- a/across/tools/visibility/ephemeris_visibility.py
+++ b/across/tools/visibility/ephemeris_visibility.py
@@ -108,6 +108,13 @@ class EphemerisVisibility(Visibility):
             self.ephemeris.index(self.begin) : self.ephemeris.index(self.end)
         ]
 
+    def _merge_computed_values(self) -> None:
+        """
+        Merge computed values from all constraints into the main computed_values attribute.
+        """
+        for constraint in self.constraints:
+            self.computed_values.merge(constraint.computed_values)
+
     def _find_violated_constraint(self, constraint: ConstraintABC, index: int) -> ConstraintType:
         """
         Find which actual constraint is violated at a given index.

--- a/across/tools/visibility/joint_visibility.py
+++ b/across/tools/visibility/joint_visibility.py
@@ -128,6 +128,14 @@ class JointVisibility(Visibility, Generic[T]):
         # Compute joint visibility by ORing all inconstraint arrays
         self.inconstraint = np.any([vis.inconstraint for vis in self.visibilities], axis=0)
 
+    def _merge_computed_values(self) -> None:
+        """
+        Abstract method to merge computed values from constraints.
+        """
+        for visibility in self.visibilities:
+            if visibility.computed_values is not None:
+                self.computed_values.merge(visibility.computed_values)
+
 
 def compute_joint_visibility(
     visibilities: list[T],

--- a/tests/tools/visibility/ephemeris_visibility_test.py
+++ b/tests/tools/visibility/ephemeris_visibility_test.py
@@ -1,4 +1,5 @@
 import uuid
+from typing import Any
 
 import numpy as np
 import pytest
@@ -65,6 +66,50 @@ class TestEphemerisVisibility:
         with pytest.raises(ValueError, match="Timestamp not computed. Call prepare_data\\(\\) first."):
             first_true_index = int(np.argmax(earth_constraints))
             test_visibility._constraint(first_true_index)
+
+    def test_merge_computed_values_earth(
+        self, test_visibility: EphemerisVisibility, mock_constraint_class: Any
+    ) -> None:
+        """Test _merge_computed_values with Earth constraint."""
+        mock_earth_constraint = mock_constraint_class(ConstraintType.EARTH, "earth_angle")
+        test_visibility.constraints = [mock_earth_constraint]
+        test_visibility._merge_computed_values()
+
+        assert (
+            test_visibility.computed_values.earth_angle == mock_earth_constraint.computed_values.earth_angle
+        )
+
+    def test_merge_computed_values_sun(
+        self, test_visibility: EphemerisVisibility, mock_constraint_class: Any
+    ) -> None:
+        """Test _merge_computed_values with Sun constraint."""
+        mock_sun_constraint = mock_constraint_class(ConstraintType.SUN, "sun_angle")
+        test_visibility.constraints = [mock_sun_constraint]
+        test_visibility._merge_computed_values()
+
+        assert test_visibility.computed_values.sun_angle == mock_sun_constraint.computed_values.sun_angle
+
+    def test_merge_computed_values_moon(
+        self, test_visibility: EphemerisVisibility, mock_constraint_class: Any
+    ) -> None:
+        """Test _merge_computed_values with Moon constraint."""
+        mock_moon_constraint = mock_constraint_class(ConstraintType.MOON, "moon_angle")
+        test_visibility.constraints = [mock_moon_constraint]
+        test_visibility._merge_computed_values()
+
+        assert test_visibility.computed_values.moon_angle == mock_moon_constraint.computed_values.moon_angle
+
+    def test_merge_computed_values_alt_az(
+        self,
+        test_visibility: EphemerisVisibility,
+        mock_constraint_class: Any,
+    ) -> None:
+        """Test _merge_computed_values with AltAz constraint."""
+        mock_alt_az_constraint = mock_constraint_class(ConstraintType.ALT_AZ, "alt_az")
+        test_visibility.constraints = [mock_alt_az_constraint]
+        test_visibility._merge_computed_values()
+
+        assert test_visibility.computed_values.alt_az == mock_alt_az_constraint.computed_values.alt_az
 
     def test_no_constraints(
         self,

--- a/tests/tools/visibility/joint_visibility_test.py
+++ b/tests/tools/visibility/joint_visibility_test.py
@@ -180,6 +180,17 @@ class TestComputeJointVisibility:
             == expected_joint_visibility_windows[0].model_dump()[field]
         )
 
+    def test_compute_joint_visibility_computed_values_pass_through(
+        self, computed_joint_visibility: JointVisibility[EphemerisVisibility]
+    ) -> None:
+        """JointVisibility should pass through computed_values from input visibilities"""
+        # The joint visibility should have computed_values from the first visibility
+        # that has them (in this case, both visibilities should have earth_angle)
+        assert computed_joint_visibility.computed_values.earth_angle is not None
+        assert computed_joint_visibility.computed_values.sun_angle is None
+        assert computed_joint_visibility.computed_values.moon_angle is None
+        assert computed_joint_visibility.computed_values.alt_az is None
+
     def test_compute_joint_visibility_should_return_empty_list_if_no_windows(
         self,
         computed_visibility: EphemerisVisibility,


### PR DESCRIPTION
## Title

feat(visibility): allow visibility constraints to record calculated values in output 

### Description

Implementation of computed visibility values feature with full support for logical constraints, joint visibility pass-through, and comprehensive testing. This enables visibility calculations to return detailed angular data (sun, moon, earth angles) for pass through to users for use in plots, analysis etc.

The implementation of the computed_values uses a Pydantic model `VisibilityComputedValues`. This currently has the form:
```python
class VisibilityComputedValues(BaseSchema):
    sun_angle: u.Quantity | None
    moon_angle: u.Quantity | None
    earth_angle: u.Quantity | None
    alt_az: SkyCoord | None
```
so as more constraints are added that use different calculated values, this will need to be updated with new values. Downside of this, every added value could translate to an API change on the server side if we want to pass these values through. A simple fix for this would be to make the API version of this field free-form, to allow entries to be added without making breaking changes to the API. 

As this implementation is purely on the tools side right now, this change does not affect the function of `across-server`. In fact I have tested `across-server` with this PR and it functions as normal, so adding `computed_values` support to the server side will require a server PR.

### Related Issue(s)

Resolves #49 

### Reviewers

@NASA-ACROSS/developers 

### Acceptance Criteria

- Visibility calculations populate `computed_values` with full timestamp arrays (sun_angle, moon_angle, earth_angle, alt_az)
- Logical constraints (OR, AND, XOR, NOT) properly merge computed values from sub-constraints
- JointVisibility passes through computed values from individual visibilities
- All constraint types (Sun, Moon, Earth, AltAz, SAA) populate computed values correctly
- Comprehensive test coverage for all scenarios
- No breaking changes to existing API

### Testing

* 100% test coverage of updated code
* Run e.g. Swift calculator code from previous PR (e.g. https://github.com/NASA-ACROSS/across-tools/pull/98) and look at contents of `vis.computed_values`, verify that this contains computed sun, moon and earth angles for the computed time period.
