### PR TITLE
fix: issue where constraint type of a combined constraint can return unknown

### DIFF
--- a/across/tools/visibility/ephemeris_visibility.py
+++ b/across/tools/visibility/ephemeris_visibility.py
@@ -142,12 +142,14 @@ class EphemerisVisibility(Visibility):
         if isinstance(constraint, (OrConstraint, AndConstraint, XorConstraint)):
             # For OR: any sub-constraint that is violated
             for sub_constraint in constraint.constraints:
+                # Evaluate on full timestamp array to avoid slicing issues with get_slice
                 sub_result = sub_constraint(
-                    time=self.timestamp[index : index + 1],
+                    time=self.timestamp,
                     ephemeris=self.ephemeris,
                     coordinate=self.coordinate,
                 )
-                if sub_result[0]:  # If this constraint is violated
+                # Check if this constraint is violated at the specific index
+                if sub_result[index]:
                     return self._find_violated_constraint(sub_constraint, index)
             return ConstraintType.UNKNOWN
 


### PR DESCRIPTION

## Title

fix: issue where constraint type of a combined constraint can return unknown

### Description

This PR fixes a bug that could sometimes lead to a logical-operator constructed constraint returned `ConstraintType.Unknown` incorrectly. This PR fixes that bug. The bug only affected constraints constructed using logical operators. 

### Related Issue(s)

Resolves #113 

### Reviewers

@NASA-ACROSS/developers 

### Acceptance Criteria

Example code given in Issue, and or modifications of that code pass.

### Testing

Unit tests pass 100%. 

This code:

```python
from datetime import datetime

import astropy.units as u
from astropy.coordinates import EarthLocation, SkyCoord

from across.tools.ephemeris import GroundEphemeris
from across.tools.visibility.constraints import (
    AirmassConstraint, AltAzConstraint
)
from across.tools.visibility import compute_ephemeris_visibility

paranal = EarthLocation.of_site("paranal")

begin = datetime(2026, 2, 3)
end = datetime(2026, 2, 4)

ephem = GroundEphemeris(
    begin=begin, end=end, latitude=paranal.lat, longitude=paranal.lon, height=paranal.height
)
ephem.compute()

constraints = AirmassConstraint(max_air_mass=2.0) | AltAzConstraint(min_altitude=30 * u.deg)



vis = compute_ephemeris_visibility(
    begin=ephem.timestamp[0],
    end=ephem.timestamp[-1],
    ephemeris=ephem,
    constraints=constraints,
    coordinate=SkyCoord(ra=10 * u.deg, dec=20 * u.deg),
)

print(vis.visibility_windows[0].constraint_reason)
```
should return that the cause of the first window constraint is air mass, not unknown.


