### PR TITLE
fix(tle): use space track recommended parameters for retrieving newest TLEs

### DIFF
--- a/across/tools/tle/tle.py
+++ b/across/tools/tle/tle.py
@@ -5,7 +5,6 @@
 
 import logging
 import re
-from datetime import datetime, timedelta
 from typing import TypedDict
 
 from httpx import HTTPStatusError
@@ -35,8 +34,6 @@ class TLEFetch:
     satellites : list[NoradSatellite]
         List of satellites to query, each with 'name' and 'id' keys.
         Only the id is used to query against spacetrack_client.gp norad_cat_id
-    epoch : datetime
-        Epoch of TLE to retrieve.
     spacetrack_user : str, optional
         Space-Track.org username. Falls back to SPACETRACK_USER config.
     spacetrack_pwd : str, optional
@@ -48,8 +45,6 @@ class TLEFetch:
     ----------
     satellites : list[NoradSatellite]
         List of satellites with name and NORAD ID.
-    epoch : datetime
-        Epoch of the TLE
     spacetrack_user : str, optional
         Space-Track.org username
     spacetrack_pwd  : str, optional
@@ -76,7 +71,6 @@ class TLEFetch:
 
     # Configuration parameters
     satellites: list[NoradSatellite]
-    epoch: datetime
     spacetrack_user: str | None
     spacetrack_pwd: str | None
     spacetrack_base_url: str | None
@@ -84,7 +78,6 @@ class TLEFetch:
     def __init__(
         self,
         satellites: list[NoradSatellite],
-        epoch: datetime,
         spacetrack_user: str | None = None,
         spacetrack_pwd: str | None = None,
         spacetrack_base_url: str | None = None,
@@ -104,7 +97,6 @@ class TLEFetch:
                 raise TypeError("satellite 'id' must be an integer")
 
         self.satellites = satellites
-        self.epoch = epoch
         self.spacetrack_user = spacetrack_user or config.SPACETRACK_USER
         self.spacetrack_pwd = spacetrack_pwd or config.SPACETRACK_PWD
         self.spacetrack_base_url = spacetrack_base_url
@@ -137,10 +129,6 @@ class TLEFetch:
         if not self.satellites:
             return []
 
-        # Build space-track.org query
-        epoch_start = self.epoch - timedelta(days=7)
-        epoch_stop = self.epoch + timedelta(days=7)
-
         spacetrack_client_args = {"identity": self.spacetrack_user, "password": self.spacetrack_pwd}
 
         # set base_url when provided upstream to override space-track server to access
@@ -159,10 +147,10 @@ class TLEFetch:
 
             # Fetch the TLEs between the requested epochs
             tletext = spacetrack_client.gp(
+                decay_date="null-val",
+                creation_date=">now-0.5",
                 norad_cat_id=norad_ids,
-                orderby="epoch desc",
                 format="tle",
-                epoch=f">{epoch_start},<{epoch_stop}",
             )
 
         # Check if we got a return
@@ -209,7 +197,6 @@ class TLEFetch:
 
 def get_tle(
     satellites: list[NoradSatellite],
-    epoch: datetime,
     spacetrack_user: str | None = None,
     spacetrack_pwd: str | None = None,
     spacetrack_base_url: str | None = None,
@@ -223,8 +210,6 @@ def get_tle(
     ----------
     satellites : list[NoradSatellite]
         List of satellites to query, each with 'name' and 'id' keys.
-    epoch : datetime
-        The epoch timestamp for which to retrieve the TLE data.
     spacetrack_user : str, optional
         space-Track.org username.
     spacetrack_pwd : str, optional
@@ -252,7 +237,6 @@ def get_tle(
 
     tle = TLEFetch(
         satellites=satellites,
-        epoch=epoch,
         spacetrack_user=spacetrack_user,
         spacetrack_pwd=spacetrack_pwd,
         spacetrack_base_url=spacetrack_base_url,

--- a/tests/tools/tle/conftest.py
+++ b/tests/tools/tle/conftest.py
@@ -1,5 +1,4 @@
 from collections.abc import Generator
-from datetime import datetime
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -83,7 +82,6 @@ def tle_fetch_object() -> Generator[TLEFetch]:
     """Example TLEFetch object."""
     yield TLEFetch(
         satellites=[{"name": "ISS", "id": 25544}],
-        epoch=datetime(2008, 9, 20),
         spacetrack_user="user",
         spacetrack_pwd="pass",
     )

--- a/tests/tools/tle/tle_fetch_test.py
+++ b/tests/tools/tle/tle_fetch_test.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -16,10 +15,6 @@ class TestTLEFetch:
     def test_init_satellites(self, tle_fetch_object: TLEFetch) -> None:
         """Test TLEFetch initialization satellites."""
         assert tle_fetch_object.satellites == [{"name": "ISS", "id": 25544}]
-
-    def test_init_epoch(self, tle_fetch_object: TLEFetch) -> None:
-        """Test TLEFetch initialization epoch."""
-        assert tle_fetch_object.epoch == datetime(2008, 9, 20)
 
     def test_get_returns_correct_satellite_name_from_input(self, tle_fetch_object: TLEFetch) -> None:
         """Test TLEFetch returns satellite name from input satellites list."""
@@ -40,7 +35,7 @@ class TestTLEFetch:
     @patch.dict("os.environ", {"SPACETRACK_USER": "env_user", "SPACETRACK_PWD": "env_pass"}, clear=True)
     def test_init_with_env_vars_user(self) -> None:
         """Test TLEFetch initialization with environment variable user."""
-        tle_fetch = TLEFetch(satellites=[{"name": "ISS", "id": 25544}], epoch=datetime(2008, 9, 20))
+        tle_fetch = TLEFetch(satellites=[{"name": "ISS", "id": 25544}])
         assert tle_fetch.spacetrack_user == "env_user"
 
     @patch("across.tools.core.config.config.SPACETRACK_PWD", "env_pass")
@@ -48,33 +43,33 @@ class TestTLEFetch:
     @patch.dict("os.environ", {"SPACETRACK_USER": "env_user", "SPACETRACK_PWD": "env_pass"})
     def test_init_with_env_vars_pwd(self) -> None:
         """Test TLEFetch initialization with environment variable password."""
-        tle_fetch = TLEFetch(satellites=[{"name": "ISS", "id": 25544}], epoch=datetime(2008, 9, 20))
+        tle_fetch = TLEFetch(satellites=[{"name": "ISS", "id": 25544}])
         assert tle_fetch.spacetrack_pwd == "env_pass"
 
     def test_init_raises_type_error_if_satellites_not_list(self) -> None:
         """Test TLEFetch initialization raises TypeError if satellites is not a list."""
         with pytest.raises(TypeError):
-            TLEFetch(satellites={"name": "ISS", "id": 25544}, epoch=datetime(2008, 9, 20))  # type: ignore
+            TLEFetch(satellites={"name": "ISS", "id": 25544})  # type: ignore
 
     def test_init_raises_type_error_if_satellites_empty(self) -> None:
         """Test TLEFetch initialization raises ValueError if satellites list is empty."""
         with pytest.raises(ValueError):
-            TLEFetch(satellites=[], epoch=datetime(2008, 9, 20))
+            TLEFetch(satellites=[])
 
     def test_init_raises_type_error_if_satellite_missing_keys(self) -> None:
         """Test TLEFetch initialization raises TypeError if satellite dict lacks name or id."""
         with pytest.raises(TypeError):
-            TLEFetch(satellites=[{"name": "ISS"}], epoch=datetime(2008, 9, 20))  # type: ignore
+            TLEFetch(satellites=[{"name": "ISS"}])  # type: ignore
 
     def test_init_raises_type_error_if_satellite_name_not_string(self) -> None:
         """Test TLEFetch initialization raises TypeError if satellite name is not a string."""
         with pytest.raises(TypeError):
-            TLEFetch(satellites=[{"name": 123, "id": 25544}], epoch=datetime(2008, 9, 20))  # type: ignore
+            TLEFetch(satellites=[{"name": 123, "id": 25544}])  # type: ignore
 
     def test_init_raises_type_error_if_satellite_id_not_int(self) -> None:
         """Test TLEFetch initialization raises TypeError if satellite id is not an int."""
         with pytest.raises(TypeError):
-            TLEFetch(satellites=[{"name": "ISS", "id": "25544"}], epoch=datetime(2008, 9, 20))  # type: ignore
+            TLEFetch(satellites=[{"name": "ISS", "id": "25544"}])  # type: ignore
 
     def test_get_returns_tle_list_type(
         self,
@@ -148,7 +143,6 @@ class TestTLEFetch:
 
         tle_fetch = TLEFetch(
             satellites=[{"name": "ISS", "id": 25544}],
-            epoch=datetime(2008, 9, 20),
             spacetrack_user="user",
             spacetrack_pwd="pass",
         )
@@ -166,7 +160,6 @@ class TestTLEFetch:
 
         tle_fetch = TLEFetch(
             satellites=[{"name": "ISS", "id": 25544}, {"name": "SWIFT", "id": 28485}],
-            epoch=datetime(2008, 9, 20),
             spacetrack_user="user",
             spacetrack_pwd="pass",
         )
@@ -184,7 +177,6 @@ class TestTLEFetch:
 
         tle_fetch = TLEFetch(
             satellites=[{"name": "ISS", "id": 25544}, {"name": "SWIFT", "id": 28485}],
-            epoch=datetime(2008, 9, 20),
             spacetrack_user="user",
             spacetrack_pwd="pass",
         )
@@ -202,7 +194,6 @@ class TestTLEFetch:
 
         tle_fetch = TLEFetch(
             satellites=[{"name": "ISS", "id": 25544}, {"name": "SWIFT", "id": 28485}],
-            epoch=datetime(2008, 9, 20),
             spacetrack_user="user",
             spacetrack_pwd="pass",
         )
@@ -220,7 +211,6 @@ class TestTLEFetch:
 
         tle_fetch = TLEFetch(
             satellites=[{"name": "ISS", "id": 25544}],
-            epoch=datetime(2008, 9, 20),
             spacetrack_user="user",
             spacetrack_pwd="pass",
         )
@@ -237,7 +227,6 @@ class TestTLEFetch:
 
         tle_fetch = TLEFetch(
             satellites=[{"name": "ISS", "id": 25544}],
-            epoch=datetime(2008, 9, 20),
             spacetrack_user="user",
             spacetrack_pwd="pass",
         )
@@ -255,7 +244,6 @@ class TestTLEFetch:
 
         tle_fetch = TLEFetch(
             satellites=[{"name": "ISS", "id": 25544}],
-            epoch=datetime(2008, 9, 20),
             spacetrack_user="user",
             spacetrack_pwd="pass",
         )
@@ -277,7 +265,6 @@ class TestGetTLE:
 
         result = get_tle(
             satellites=[{"name": "ISS", "id": 25544}],
-            epoch=datetime(2008, 9, 20),
             spacetrack_user="test_user",
             spacetrack_pwd="test_pass",
         )
@@ -294,7 +281,6 @@ class TestGetTLE:
 
         result = get_tle(
             satellites=[{"name": "ISS", "id": 25544}],
-            epoch=datetime(2008, 9, 20),
             spacetrack_user="test_user",
             spacetrack_pwd="test_pass",
         )
@@ -311,7 +297,6 @@ class TestGetTLE:
 
         result = get_tle(
             satellites=[{"name": "ISS", "id": 25544}],
-            epoch=datetime(2008, 9, 20),
             spacetrack_user="test_user",
             spacetrack_pwd="test_pass",
         )
@@ -328,7 +313,6 @@ class TestGetTLE:
 
         result = get_tle(
             satellites=[{"name": "UNKNOWN", "id": 99999}],
-            epoch=datetime(2008, 9, 20),
             spacetrack_user="test_user",
             spacetrack_pwd="test_pass",
         )


### PR DESCRIPTION
### Description

Modifies TLE ingestion to use suggested URL

### Related Issue(s)

Resolves #158 

### Reviewers
@NASA-ACROSS/developers 

### Acceptance Criteria

1. the URL emitted by the tle fetch tool should match the requested URL by spacetrack

### Testing

run tle ingestion with your account

install the package locally with `python -m pip install .`

```
import logging

from datetime import datetime

from across.tools import tle as tle_tool

logging.basicConfig(level=logging.INFO)

tle = tle_tool.get_tle(
    satellites=[{"id": 25544, "name": "ISS"}, {"id": 28485, "name": "SWIFT"}],
    spacetrack_user="username",
    spacetrack_pwd="password",
    spacetrack_base_url="https://www.space-track.org/",
)

print(tle)

```
